### PR TITLE
feat(menus): Adds a feedback API.

### DIFF
--- a/src/db/models/account.ts
+++ b/src/db/models/account.ts
@@ -166,7 +166,7 @@ export class Account {
     }
   }
 
-  public async setPinAttempts(phoneNumber: string, attempts: number) {
+  public async setPinAttempts(attempts: number, phoneNumber: string) {
     const client = await this.db.connect()
     try {
       await client.query(`

--- a/src/i18n/eng/auth/index.ts
+++ b/src/i18n/eng/auth/index.ts
@@ -1,8 +1,10 @@
 import type { NamespaceAuthTranslation } from '../../i18n-types';
+import eng from '..';
+
+const { accountBlocked, exit } = eng
 
 const eng_auth: NamespaceAuthTranslation = {
-    accountBlocked:
-        "END Your PIN has been blocked. For assistance please call: {supportPhone}.",
+    accountBlocked: accountBlocked,
     processingAccount:
         "END Your account is still being created. You will receive an SMS when your account is ready.",
     enteringPin:
@@ -13,8 +15,7 @@ const eng_auth: NamespaceAuthTranslation = {
         "CON Balance: {balance|currency} {symbol}\n1. Send\n2. My Vouchers\n3. My Account\n4. Help",
     activationError:
         "END Please try again in a few minutes. If the problem persists, please contact {supportNumber|phone}",
-    exit:
-        "END Thank you for using Sarafu. Goodbye.",
+    exit: exit,
 }
 
 export default eng_auth

--- a/src/i18n/eng/feedback/index.ts
+++ b/src/i18n/eng/feedback/index.ts
@@ -1,0 +1,34 @@
+import type { NamespaceFeedbackTranslation } from '../../i18n-types'
+
+const eng_feedback: NamespaceFeedbackTranslation = {
+  invalidAmount:
+    'CON The amount you entered is greater than your balance or is invalid. Please try again:\n0. Back',
+  invalidGenderOption:
+    'CON Your gender option is invalid. Please try again:\n1. Male\n2. Female\n3. Other\n0. Back',
+  invalidLanguageOption:
+    'CON The language option is invalid. Please try again:\n{languages}\n0. Back\n00.Exit\n11. Next',
+  invalidLocationOption:
+    'CON The location entered is invalid. Please try again:\n0. Back',
+  invalidMarketplaceEntry:
+    'CON The services or goods you entered are invalid. Please try again:\n0. Back',
+  invalidName:
+    'CON The name you entered is invalid. Please try again:\n0. Back',
+  invalidNewPin:
+    'CON The PIN you entered is invalid. The PIN must be different from your current PIN. For help, call {supportPhone}.\n0. Back',
+  invalidPin:
+    'Your PIN is incorrect, you have {remainingAttempts} attempts remaining.\n0. Back',
+  invalidPinAtRegistration:
+    'CON The PIN you have entered is invalid. PIN must consist of 4 digits. For help, call {supportPhone}:\n00. Exit',
+  invalidPinPC:
+    'CON Your PIN is incorrect, you have {remainingAttempts} attempts remaining.\n0. Back',
+  invalidPinPV:
+    'CON Your PIN is incorrect, you have {remainingAttempts} attempts remaining.\n0. Back',
+  invalidVoucher:
+    'CON The voucher option is invalid. Please try again\n{vouchers}\n0. Back\n11. Next\n00. Exit',
+  invalidYOBEntry:
+    'CON The year of birth you entered is invalid. Please try again:\n0. Back',
+  pinMismatch:
+    'CON The new PIN does not match the one you entered. Please try again. For help, call {supportPhone}\n0. Back',
+}
+
+export default eng_feedback

--- a/src/i18n/i18n-types.ts
+++ b/src/i18n/i18n-types.ts
@@ -15,6 +15,7 @@ export type Translations = RootTranslation &
 {
 	auth: NamespaceAuthTranslation,
 	balances: NamespaceBalancesTranslation,
+	feedback: NamespaceFeedbackTranslation,
 	helpers: NamespaceHelpersTranslation,
 	languages: NamespaceLanguagesTranslation,
 	main: NamespaceMainTranslation,
@@ -42,10 +43,9 @@ type RootTranslation = {
 
 export type NamespaceAuthTranslation = {
 	/**
-	 * E​N​D​ ​P​I​N​ ​y​a​k​o​ ​i​m​e​f​u​n​g​w​a​.​ ​K​w​a​ ​u​s​a​i​d​i​z​i​ ​t​a​f​a​d​h​a​l​i​ ​p​i​g​a​ ​s​i​m​u​ ​k​w​a​:​ ​{​s​u​p​p​o​r​t​P​h​o​n​e​}​.
-	 * @param {unknown} supportPhone
+	 * E​N​D​ ​P​I​N​ ​y​a​k​o​ ​i​m​e​f​u​n​g​w​a​.​ ​K​w​a​ ​u​s​a​i​d​i​z​i​ ​t​a​f​a​d​h​a​l​i​ ​p​i​g​a​ ​s​i​m​u​ ​k​w​a​:​ ​0​7​5​7​6​2​8​8​8​5​.
 	 */
-	accountBlocked: RequiredParams<'supportPhone'>
+	accountBlocked: string
 	/**
 	 * E​N​D​ ​A​k​a​u​n​t​i​ ​y​a​k​o​ ​y​a​ ​S​a​r​a​f​u​ ​b​a​d​o​ ​i​n​a​t​a​y​a​r​i​s​h​w​a​.​ ​U​t​a​p​o​k​e​a​ ​u​j​u​m​b​e​ ​w​a​ ​S​M​S​ ​a​k​a​u​n​t​i​ ​y​a​k​o​ ​i​k​i​w​a​ ​t​a​y​a​r​i​.
 	 */
@@ -76,7 +76,7 @@ export type NamespaceAuthTranslation = {
 	 */
 	activationError: RequiredParams<'supportNumber|phone'>
 	/**
-	 * E​N​D​ ​A​s​a​n​t​e​ ​k​w​a​ ​k​u​t​u​m​i​a​ ​S​a​r​a​f​u​.​ ​K​w​a​h​e​r​i​.
+	 * E​N​D​ ​A​s​a​n​t​e​ ​k​w​a​ ​k​u​t​u​m​i​a​ ​h​u​d​u​m​a​ ​y​a​ ​S​a​r​a​f​u​.​ ​K​w​a​h​e​r​i​!
 	 */
 	exit: string
 }
@@ -131,6 +131,96 @@ export type NamespaceBalancesTranslation = {
 	 * @param {unknown} symbol
 	 */
 	loadSuccess: RequiredParams<'balance|currency' | 'symbol'>
+}
+
+export type NamespaceFeedbackTranslation = {
+	/**
+	 * C​O​N​ ​K​i​a​s​i​ ​u​l​i​c​h​o​t​u​m​a​ ​n​i​ ​k​i​k​u​b​w​a​ ​k​u​l​i​k​o​ ​k​i​a​s​i​ ​u​l​i​c​h​o​n​a​c​h​o​ ​a​u​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​:​
+​0​.​ ​R​u​d​i
+	 */
+	invalidAmount: string
+	/**
+	 * C​O​N​ ​C​h​a​g​u​o​ ​l​a​ ​j​i​n​s​i​a​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​:​
+​1​.​ ​M​w​a​n​a​u​m​e​
+​2​.​ ​M​w​a​n​a​m​k​e​
+​3​.​ ​N​y​i​n​g​i​n​e​
+​0​.​ ​R​u​d​i
+	 */
+	invalidGenderOption: string
+	/**
+	 * C​O​N​ ​C​h​a​g​u​o​ ​l​a​ ​l​u​g​h​a​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​:​
+​{​l​a​n​g​u​a​g​e​s​}​
+​0​.​ ​R​u​d​i​
+​0​0​.​O​n​d​o​k​a​
+​1​1​.​ ​M​b​e​l​e
+	 * @param {unknown} languages
+	 */
+	invalidLanguageOption: RequiredParams<'languages'>
+	/**
+	 * C​O​N​ ​E​n​e​o​ ​u​l​i​l​o​w​e​k​a​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​:​
+​0​.​ ​R​u​d​i
+	 */
+	invalidLocationOption: string
+	/**
+	 * C​O​N​ ​H​u​d​u​m​a​ ​a​u​ ​b​i​d​h​a​a​ ​u​l​i​y​o​w​e​k​a​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​:​
+​0​.​ ​R​u​d​i
+	 */
+	invalidMarketplaceEntry: string
+	/**
+	 * C​O​N​ ​J​i​n​a​ ​u​l​i​l​o​w​e​k​a​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​:​
+​0​.​ ​R​u​d​i
+	 */
+	invalidName: string
+	/**
+	 * C​O​N​ ​P​I​N​ ​u​l​i​y​o​b​o​n​y​e​z​a​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​P​I​N​ ​l​a​z​i​m​a​ ​i​w​e​ ​t​o​f​a​u​t​i​ ​n​a​ ​p​i​n​ ​y​a​k​o​ ​y​a​ ​s​a​s​a​.​ ​K​w​a​ ​u​s​a​i​d​i​z​i​ ​p​i​g​a​ ​s​i​m​u​ ​{​s​u​p​p​o​r​t​P​h​o​n​e​}​.​
+​0​.​ ​R​u​d​i
+	 * @param {unknown} supportPhone
+	 */
+	invalidNewPin: RequiredParams<'supportPhone'>
+	/**
+	 * C​O​N​ ​P​I​N​ ​y​a​k​o​ ​s​i​o​ ​s​a​h​i​h​i​,​ ​u​n​a​ ​m​a​j​i​r​o​b​i​o​:​ ​{​r​e​m​a​i​n​i​n​g​A​t​t​e​m​p​t​s​}​ ​y​a​l​i​y​o​b​a​k​i​.​
+​0​.​ ​R​u​d​i
+	 * @param {unknown} remainingAttempts
+	 */
+	invalidPin: RequiredParams<'remainingAttempts'>
+	/**
+	 * C​O​N​ ​P​I​N​ ​u​l​i​y​o​b​o​n​y​e​z​a​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​P​I​N​ ​l​a​z​i​m​a​ ​i​w​e​ ​n​a​ ​n​a​m​b​a​r​i​ ​n​n​e​.​ ​K​w​a​ ​u​s​a​i​d​i​z​i​ ​p​i​g​a​ ​s​i​m​u​ ​{​s​u​p​p​o​r​t​P​h​o​n​e​}​:​
+​0​0​.​ ​O​n​d​o​k​a
+	 * @param {unknown} supportPhone
+	 */
+	invalidPinAtRegistration: RequiredParams<'supportPhone'>
+	/**
+	 * C​O​N​ ​P​I​N​ ​y​a​k​o​ ​s​i​o​ ​s​a​h​i​h​i​,​ ​u​n​a​ ​m​a​j​i​r​o​b​i​o​:​ ​{​r​e​m​a​i​n​i​n​g​A​t​t​e​m​p​t​s​}​ ​y​a​l​i​y​o​b​a​k​i​.​
+​0​.​ ​R​u​d​i
+	 * @param {unknown} remainingAttempts
+	 */
+	invalidPinPC: RequiredParams<'remainingAttempts'>
+	/**
+	 * C​O​N​ ​P​I​N​ ​y​a​k​o​ ​s​i​o​ ​s​a​h​i​h​i​,​ ​u​n​a​ ​m​a​j​i​r​o​b​i​o​:​ ​{​r​e​m​a​i​n​i​n​g​A​t​t​e​m​p​t​s​}​ ​y​a​l​i​y​o​b​a​k​i​.​
+​0​.​ ​R​u​d​i
+	 * @param {unknown} remainingAttempts
+	 */
+	invalidPinPV: RequiredParams<'remainingAttempts'>
+	/**
+	 * C​O​N​ ​C​h​a​g​u​o​ ​l​a​ ​s​a​r​a​f​u​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​.​
+​{​v​o​u​c​h​e​r​s​}​
+​0​.​ ​R​u​d​i​
+​1​1​.​ ​M​b​e​l​e​
+​0​0​.​ ​O​n​d​o​k​a
+	 * @param {unknown} vouchers
+	 */
+	invalidVoucher: RequiredParams<'vouchers'>
+	/**
+	 * C​O​N​ ​M​w​a​k​a​ ​w​a​ ​k​u​z​a​l​i​w​a​ ​u​l​i​o​w​e​k​a​ ​s​i​o​ ​s​a​h​i​h​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​:​
+​0​.​ ​R​u​d​i
+	 */
+	invalidYOBEntry: string
+	/**
+	 * C​O​N​ ​P​I​N​ ​m​p​y​a​ ​n​a​ ​u​d​h​i​b​i​t​i​s​h​o​ ​w​a​ ​p​i​n​ ​m​p​y​a​ ​h​a​z​i​l​i​n​g​a​n​i​.​ ​T​a​f​a​d​h​a​l​i​ ​j​a​r​i​b​u​ ​t​e​n​a​.​ ​K​w​a​ ​u​s​a​i​d​i​z​i​ ​p​i​g​a​ ​s​i​m​u​ ​{​s​u​p​p​o​r​t​P​h​o​n​e​}​.​
+​0​.​ ​R​u​d​i
+	 * @param {unknown} supportPhone
+	 */
+	pinMismatch: RequiredParams<'supportPhone'>
 }
 
 export type NamespaceHelpersTranslation = {
@@ -867,6 +957,7 @@ export type NamespaceVoucherTranslation = {
 export type Namespaces =
 	| 'auth'
 	| 'balances'
+	| 'feedback'
 	| 'helpers'
 	| 'languages'
 	| 'main'
@@ -892,6 +983,12 @@ type DisallowNamespaces = {
 	 * you need to use the `./balances/index.ts` file instead
 	 */
 	balances?: "[typesafe-i18n] reserved for 'balances'-namespace. You need to use the `./balances/index.ts` file instead."
+
+	/**
+	 * reserved for 'feedback'-namespace\
+	 * you need to use the `./feedback/index.ts` file instead
+	 */
+	feedback?: "[typesafe-i18n] reserved for 'feedback'-namespace. You need to use the `./feedback/index.ts` file instead."
 
 	/**
 	 * reserved for 'helpers'-namespace\
@@ -977,9 +1074,9 @@ export type TranslationFunctions = {
 	exit: () => LocalizedString
 	auth: {
 		/**
-		 * END PIN yako imefungwa. Kwa usaidizi tafadhali piga simu kwa: {supportPhone}.
+		 * END PIN yako imefungwa. Kwa usaidizi tafadhali piga simu kwa: 0757628885.
 		 */
-		accountBlocked: (arg: { supportPhone: unknown }) => LocalizedString
+		accountBlocked: () => LocalizedString
 		/**
 		 * END Akaunti yako ya Sarafu bado inatayarishwa. Utapokea ujumbe wa SMS akaunti yako ikiwa tayari.
 		 */
@@ -1007,7 +1104,7 @@ export type TranslationFunctions = {
 		 */
 		activationError: (arg: { supportNumber: unknown }) => LocalizedString
 		/**
-		 * END Asante kwa kutumia Sarafu. Kwaheri.
+		 * END Asante kwa kutumia huduma ya Sarafu. Kwaheri!
 		 */
 		exit: () => LocalizedString
 	}
@@ -1057,6 +1154,87 @@ export type TranslationFunctions = {
 	9. Ondoka
 		 */
 		loadSuccess: (arg: { balance: unknown, symbol: unknown }) => LocalizedString
+	}
+	feedback: {
+		/**
+		 * CON Kiasi ulichotuma ni kikubwa kuliko kiasi ulichonacho au sio sahihi. Tafadhali jaribu tena:
+	0. Rudi
+		 */
+		invalidAmount: () => LocalizedString
+		/**
+		 * CON Chaguo la jinsia sio sahihi. Tafadhali jaribu tena:
+	1. Mwanaume
+	2. Mwanamke
+	3. Nyingine
+	0. Rudi
+		 */
+		invalidGenderOption: () => LocalizedString
+		/**
+		 * CON Chaguo la lugha sio sahihi. Tafadhali jaribu tena:
+	{languages}
+	0. Rudi
+	00.Ondoka
+	11. Mbele
+		 */
+		invalidLanguageOption: (arg: { languages: unknown }) => LocalizedString
+		/**
+		 * CON Eneo uliloweka sio sahihi. Tafadhali jaribu tena:
+	0. Rudi
+		 */
+		invalidLocationOption: () => LocalizedString
+		/**
+		 * CON Huduma au bidhaa uliyoweka sio sahihi. Tafadhali jaribu tena:
+	0. Rudi
+		 */
+		invalidMarketplaceEntry: () => LocalizedString
+		/**
+		 * CON Jina uliloweka sio sahihi. Tafadhali jaribu tena:
+	0. Rudi
+		 */
+		invalidName: () => LocalizedString
+		/**
+		 * CON PIN uliyobonyeza sio sahihi. PIN lazima iwe tofauti na pin yako ya sasa. Kwa usaidizi piga simu {supportPhone}.
+	0. Rudi
+		 */
+		invalidNewPin: (arg: { supportPhone: unknown }) => LocalizedString
+		/**
+		 * CON PIN yako sio sahihi, una majirobio: {remainingAttempts} yaliyobaki.
+	0. Rudi
+		 */
+		invalidPin: (arg: { remainingAttempts: unknown }) => LocalizedString
+		/**
+		 * CON PIN uliyobonyeza sio sahihi. PIN lazima iwe na nambari nne. Kwa usaidizi piga simu {supportPhone}:
+	00. Ondoka
+		 */
+		invalidPinAtRegistration: (arg: { supportPhone: unknown }) => LocalizedString
+		/**
+		 * CON PIN yako sio sahihi, una majirobio: {remainingAttempts} yaliyobaki.
+	0. Rudi
+		 */
+		invalidPinPC: (arg: { remainingAttempts: unknown }) => LocalizedString
+		/**
+		 * CON PIN yako sio sahihi, una majirobio: {remainingAttempts} yaliyobaki.
+	0. Rudi
+		 */
+		invalidPinPV: (arg: { remainingAttempts: unknown }) => LocalizedString
+		/**
+		 * CON Chaguo la sarafu sio sahihi. Tafadhali jaribu tena.
+	{vouchers}
+	0. Rudi
+	11. Mbele
+	00. Ondoka
+		 */
+		invalidVoucher: (arg: { vouchers: unknown }) => LocalizedString
+		/**
+		 * CON Mwaka wa kuzaliwa ulioweka sio sahihi. Tafadhali jaribu tena:
+	0. Rudi
+		 */
+		invalidYOBEntry: () => LocalizedString
+		/**
+		 * CON PIN mpya na udhibitisho wa pin mpya hazilingani. Tafadhali jaribu tena. Kwa usaidizi piga simu {supportPhone}.
+	0. Rudi
+		 */
+		pinMismatch: (arg: { supportPhone: unknown }) => LocalizedString
 	}
 	helpers: {
 		/**

--- a/src/i18n/i18n-util.async.ts
+++ b/src/i18n/i18n-util.async.ts
@@ -14,6 +14,7 @@ const localeNamespaceLoaders = {
 	eng: {
 		auth: () => import('./eng/auth'),
 		balances: () => import('./eng/balances'),
+		feedback: () => import('./eng/feedback'),
 		helpers: () => import('./eng/helpers'),
 		languages: () => import('./eng/languages'),
 		main: () => import('./eng/main'),
@@ -30,6 +31,7 @@ const localeNamespaceLoaders = {
 	swa: {
 		auth: () => import('./swa/auth'),
 		balances: () => import('./swa/balances'),
+		feedback: () => import('./swa/feedback'),
 		helpers: () => import('./swa/helpers'),
 		languages: () => import('./swa/languages'),
 		main: () => import('./swa/main'),

--- a/src/i18n/i18n-util.sync.ts
+++ b/src/i18n/i18n-util.sync.ts
@@ -10,6 +10,7 @@ import swa from './swa'
 
 import eng_auth from './eng/auth'
 import eng_balances from './eng/balances'
+import eng_feedback from './eng/feedback'
 import eng_helpers from './eng/helpers'
 import eng_languages from './eng/languages'
 import eng_main from './eng/main'
@@ -24,6 +25,7 @@ import eng_transfer from './eng/transfer'
 import eng_voucher from './eng/voucher'
 import swa_auth from './swa/auth'
 import swa_balances from './swa/balances'
+import swa_feedback from './swa/feedback'
 import swa_helpers from './swa/helpers'
 import swa_languages from './swa/languages'
 import swa_main from './swa/main'
@@ -42,6 +44,7 @@ const localeTranslations = {
 		...eng,
 		auth: eng_auth,
 		balances: eng_balances,
+		feedback: eng_feedback,
 		helpers: eng_helpers,
 		languages: eng_languages,
 		main: eng_main,
@@ -59,6 +62,7 @@ const localeTranslations = {
 		...swa,
 		auth: swa_auth,
 		balances: swa_balances,
+		feedback: swa_feedback,
 		helpers: swa_helpers,
 		languages: swa_languages,
 		main: swa_main,

--- a/src/i18n/i18n-util.ts
+++ b/src/i18n/i18n-util.ts
@@ -18,6 +18,7 @@ export const locales: Locales[] = [
 export const namespaces: Namespaces[] = [
 	'auth',
 	'balances',
+	'feedback',
 	'helpers',
 	'languages',
 	'main',

--- a/src/i18n/swa/auth/index.ts
+++ b/src/i18n/swa/auth/index.ts
@@ -1,8 +1,11 @@
 import { NamespaceAuthTranslation } from '../../i18n-types';
 
+import swa from '..';
+
+const { accountBlocked, exit } = swa
+
 const swa_auth: NamespaceAuthTranslation  = {
-    accountBlocked:
-        "END PIN yako imefungwa. Kwa usaidizi tafadhali piga simu kwa: {supportPhone}.",
+    accountBlocked: accountBlocked,
     processingAccount:
         "END Akaunti yako ya Sarafu bado inatayarishwa. Utapokea ujumbe wa SMS akaunti yako ikiwa tayari.",
     enteringPin:
@@ -13,8 +16,7 @@ const swa_auth: NamespaceAuthTranslation  = {
         "CON Salio: {balance|currency} {symbol}\n1. Tuma\n2. Sarafu yangu\n3. Akaunti yangu\n4. Usaidizi",
     activationError:
         "END Tafadhali jaribu tena baada ya dakika chache. Kama tatizo linaendelea, tafadhali wasiliana na {supportNumber|phone}.",
-    exit:
-        "END Asante kwa kutumia Sarafu. Kwaheri.",
+    exit: exit,
 }
 
 export default swa_auth

--- a/src/i18n/swa/feedback/index.ts
+++ b/src/i18n/swa/feedback/index.ts
@@ -1,0 +1,34 @@
+import { NamespaceFeedbackTranslation } from '../../i18n-types';
+
+const swa_feedback: NamespaceFeedbackTranslation = {
+  invalidAmount:
+    'CON Kiasi ulichotuma ni kikubwa kuliko kiasi ulichonacho au sio sahihi. Tafadhali jaribu tena:\n0. Rudi',
+  invalidGenderOption:
+   'CON Chaguo la jinsia sio sahihi. Tafadhali jaribu tena:\n1. Mwanaume\n2. Mwanamke\n3. Nyingine\n0. Rudi',
+  invalidLanguageOption:
+    'CON Chaguo la lugha sio sahihi. Tafadhali jaribu tena:\n{languages}\n0. Rudi\n00.Ondoka\n11. Mbele',
+  invalidLocationOption:
+    'CON Eneo uliloweka sio sahihi. Tafadhali jaribu tena:\n0. Rudi',
+  invalidMarketplaceEntry:
+    'CON Huduma au bidhaa uliyoweka sio sahihi. Tafadhali jaribu tena:\n0. Rudi',
+  invalidName:
+    'CON Jina uliloweka sio sahihi. Tafadhali jaribu tena:\n0. Rudi',
+  invalidNewPin:
+    'CON PIN uliyobonyeza sio sahihi. PIN lazima iwe tofauti na pin yako ya sasa. Kwa usaidizi piga simu {supportPhone}.\n0. Rudi',
+  invalidPin:
+    'CON PIN yako sio sahihi, una majirobio: {remainingAttempts} yaliyobaki.\n0. Rudi',
+  invalidPinAtRegistration:
+    'CON PIN uliyobonyeza sio sahihi. PIN lazima iwe na nambari nne. Kwa usaidizi piga simu {supportPhone}:\n00. Ondoka',
+  invalidPinPC:
+    'CON PIN yako sio sahihi, una majirobio: {remainingAttempts} yaliyobaki.\n0. Rudi',
+  invalidPinPV:
+    'CON PIN yako sio sahihi, una majirobio: {remainingAttempts} yaliyobaki.\n0. Rudi',
+  invalidVoucher:
+    'CON Chaguo la sarafu sio sahihi. Tafadhali jaribu tena.\n{vouchers}\n0. Rudi\n11. Mbele\n00. Ondoka',
+  invalidYOBEntry:
+    'CON Mwaka wa kuzaliwa ulioweka sio sahihi. Tafadhali jaribu tena:\n0. Rudi',
+  pinMismatch:
+    'CON PIN mpya na udhibitisho wa pin mpya hazilingani. Tafadhali jaribu tena. Kwa usaidizi piga simu {supportPhone}.\n0. Rudi',
+}
+
+export default swa_feedback

--- a/src/i18n/translators.ts
+++ b/src/i18n/translators.ts
@@ -1,7 +1,13 @@
 import { L } from './i18n-node';
-import { Locales, NamespaceHelpersTranslation, NamespaceSmsTranslation } from './i18n-types';
+import {
+  Locales,
+  NamespaceFeedbackTranslation,
+  NamespaceHelpersTranslation,
+  NamespaceSmsTranslation
+} from './i18n-types';
 import { baseLocale } from './i18n-util';
 import { menuPages } from '@lib/ussd';
+import { LocalizedString } from 'typesafe-i18n';
 
 
 export const supportedLanguages = {
@@ -33,7 +39,11 @@ export function tSMS<K extends keyof NamespaceSmsTranslation>(key: K, language: 
   return L[language]["sms"][key](data)
 }
 
-export async function translate(state: string, translator: any, data?: Record<string, any>): Promise<string> {
+export function tFeedback<K extends keyof NamespaceFeedbackTranslation>(key: K, language: Locales, data?: any) {
+  return L[language]["feedback"][key](data)
+}
+
+export async function translate(state: string, translator: any, data?: Record<string, any>): Promise<LocalizedString> {
   if (data) {
     return translator[state](data);
   } else {

--- a/src/machines/balances.ts
+++ b/src/machines/balances.ts
@@ -9,7 +9,7 @@ import {
   updateErrorMessages,
   UserContext
 } from '@machines/utils';
-import { createMachine, raise } from 'xstate';
+import { createMachine, send } from 'xstate';
 import { isBlocked, validatePin } from '@machines/auth';
 import { MachineError, SystemError } from '@lib/errors';
 import { getSinkAddress, retrieveWalletBalance } from '@lib/ussd';
@@ -117,14 +117,14 @@ export const stateMachine = createMachine<BalancesContext, MachineEvent>({
     },
     invalidPinA: {
       description: 'Entered PIN is invalid. Raises a RETRY event to prompt user to retry pin entry.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidPin' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidPin' }),
       on: {
         RETRY: 'enteringPinA'
       }
     },
     invalidPinC: {
       description: 'Entered PIN is invalid. Raises a RETRY event to prompt user to retry pin entry.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidPin' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidPin' }),
       on: {
         RETRY: 'enteringPinA'
       }
@@ -217,11 +217,11 @@ async function balancesTranslations(context: BalancesContext, state: string, tra
   const { data, user: { vouchers: { active: { balance, symbol } } } } = context;
   switch (state) {
     case "loadSuccess":
-      return translate(state, translator, { balance, symbol });
+      return await translate(state, translator, { balance, symbol });
     case "fetchSuccess":
-      return translate(state, translator, { balance: data.communityBalance, symbol });
+      return await translate(state, translator, { balance: data.communityBalance, symbol });
     default:
-      return translate(state, translator);
+      return await translate(state, translator);
   }
 }
 

--- a/src/machines/languages.ts
+++ b/src/machines/languages.ts
@@ -11,7 +11,7 @@ import {
   updateErrorMessages,
   UserContext
 } from '@machines/utils';
-import { createMachine, raise } from 'xstate';
+import { createMachine, send } from 'xstate';
 import { isBlocked, validatePin } from '@machines/auth';
 import { ContextError, MachineError } from '@lib/errors';
 import { Locales } from '@i18n/i18n-types';
@@ -97,14 +97,14 @@ const stateMachine = createMachine<LanguagesContext, MachineEvent>({
     },
     invalidLanguageOption: {
       description: 'The entered language option is invalid. Raises a RETRY event to prompt user to retry language selection.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidLanguage' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidLanguageOption' }),
       on: {
         RETRY: 'firstLanguageSet'
       }
     },
     invalidPin: {
       description: 'Entered PIN is invalid. Raises a RETRY event to prompt user to retry PIN entry.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidPin' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidPin' }),
       on: {
         RETRY: 'enteringPin'
       }

--- a/src/machines/registration.ts
+++ b/src/machines/registration.ts
@@ -1,4 +1,4 @@
-import { createMachine, raise } from 'xstate';
+import { createMachine, send } from 'xstate';
 import {
   isOption00,
   isOption11,
@@ -69,7 +69,7 @@ const stateMachine = createMachine<RegistrationContext, MachineEvent>({
     },
     invalidLanguageOption: {
       description: 'Entered language option is invalid. Raises RETRY event to retry language selection.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidLanguageOption' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidLanguageOption' }),
       on: {
         RETRY: 'firstLanguageSet'
       }
@@ -210,13 +210,13 @@ async function registrationTranslations(context: any, state: string, translator:
   const languages = await languageOptions()
   switch(state){
     case "firstLanguageSet":
-      return translate(state, translator,{ languages: languages[0] })
+      return await translate(state, translator,{ languages: languages[0] })
     case "secondLanguageSet":
-      return translate(state, translator,{ languages: languages[1] })
+      return await translate(state, translator,{ languages: languages[1] })
     case "thirdLanguageSet":
-      return translate(state, translator,{ languages: languages[2] })
+      return await translate(state, translator,{ languages: languages[2] })
     default:
-      return translate(state, translator)
+      return await translate(state, translator)
   }
 }
 

--- a/src/machines/socialRecovery.ts
+++ b/src/machines/socialRecovery.ts
@@ -1,4 +1,4 @@
-import { createMachine, raise } from 'xstate';
+import { createMachine, send } from 'xstate';
 import {
   isOption00,
   isOption1,
@@ -196,21 +196,21 @@ export const stateMachine = createMachine<SocialRecoveryContext, MachineEvent>({
     },
     invalidPinAG: {
       description: 'Entered PIN does not match the previously entered PIN. Raises a RETRY event to prompt user to retry pin entry.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidPin' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidPin' }),
       on: {
         RETRY: 'enteringPinAG'
       }
     },
     invalidPinRG: {
       description: 'Entered PIN does not match the previously entered PIN. Raises a RETRY event to prompt user to retry pin entry.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidPin' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidPin' }),
       on: {
         RETRY: 'enteringPinRG'
       }
     },
     invalidPinVG: {
       description: 'Entered PIN does not match the previously entered PIN. Raises a RETRY event to prompt user to retry pin entry.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidPin' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidPin' }),
       on: {
         RETRY: 'enteringPinVG'
       }

--- a/src/machines/statement.ts
+++ b/src/machines/statement.ts
@@ -1,4 +1,4 @@
-import { createMachine, raise } from 'xstate';
+import { createMachine, send } from 'xstate';
 import {
   isOption00,
   isOption11,
@@ -80,7 +80,7 @@ export const stateMachine = createMachine<StatementContext, MachineEvent>({
     },
     invalidPin: {
       description: 'Entered PIN is invalid. Raises a RETRY event to prompt user to retry PIN entry.',
-      entry: raise({ type: 'RETRY', feedback: 'invalidPin' }),
+      entry: send({ type: 'RETRY', feedback: 'invalidPin' }),
       on: {
         RETRY: 'enteringPin'
       }

--- a/src/machines/transfer.ts
+++ b/src/machines/transfer.ts
@@ -1,4 +1,4 @@
-import { createMachine, raise } from 'xstate';
+import { createMachine, send } from 'xstate';
 import {
   isOption1,
   isOption9,
@@ -90,7 +90,7 @@ export const stateMachine = createMachine<TransferContext, MachineEvent>({
       },
       invalidAmount: {
         description: 'Entered amount is invalid. Raise RETRY event to prompt user to re-enter amount.',
-        entry: raise({ type: 'RETRY', feedback: 'invalidAmount' }),
+        entry: send({ type: 'RETRY', feedback: 'invalidAmount' }),
         on: {
           RETRY: 'enteringAmount'
         }
@@ -152,7 +152,7 @@ export const stateMachine = createMachine<TransferContext, MachineEvent>({
       },
       invalidPin: {
         description: 'Entered pin is invalid. Raise RETRY event to prompt user to re-enter pin.',
-        entry: raise({ type: 'RETRY', feedback: 'invalidPin' }),
+        entry: send({ type: 'RETRY', feedback: 'invalidPin' }),
         on: {
           RETRY: 'enteringPin'
         },

--- a/src/machines/utils.ts
+++ b/src/machines/utils.ts
@@ -10,6 +10,8 @@ import { CountryCode } from 'libphonenumber-js';
 import { translate } from '@i18n/translators';
 import { StateMachine } from 'xstate';
 import { getPhoneNumberFromAddress } from '@services/account';
+import { NamespaceFeedbackTranslation } from '@i18n/i18n-types';
+import { LocalizedString } from 'typesafe-i18n';
 
 export enum MachineId {
   AUTH = "auth",
@@ -38,7 +40,7 @@ export type Connections = {
 
 export type MachineEvent =
   | { type: "BACK" }
-  | { type: "RETRY", feedback: string }
+  | { type: "RETRY", feedback: keyof NamespaceFeedbackTranslation}
   | { type: "TRANSIT", input: string }
 
 export interface BaseContext {
@@ -50,7 +52,7 @@ export interface BaseContext {
 
 export interface MachineInterface {
   stateMachine: StateMachine<any, any, MachineEvent>,
-  translate: (context: any, state: string, translator: any) => Promise<string>,
+  translate: (context: any, state: string, translator: any) => Promise<LocalizedString>,
 }
 
 export interface MachineServiceInterface {

--- a/src/services/account.ts
+++ b/src/services/account.ts
@@ -155,7 +155,7 @@ export class AccountService {
 
   public async updatePinAttempts(phoneNumber: string, pinAttempts: number) {
     const results = await Promise.allSettled([
-      new Account(this.db).setPinAttempts(phoneNumber, pinAttempts),
+      new Account(this.db).setPinAttempts(pinAttempts, phoneNumber),
       this.updateCache(phoneNumber, { account: { pin_attempts: pinAttempts } })
     ])
     await handleResults(results)


### PR DESCRIPTION
- Adds translations for menu errors.
- Switches from raise to send in machined to make RETRY events visible to the outside of the machine.
- Standardizes account-blocked messages with a single source of truth.

Closes #46
Closes #44
Closes #23