### PR TITLE
Locks np version to 8.19.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:18-alpine3.15 AS base
 WORKDIR /app
 
 COPY package*.json ./
-RUN npm install -g npm@latest
+RUN npm install -g npm@8.19.2
 RUN npm ci --omit=dev --omit=optional
 
 # build stage


### PR DESCRIPTION
Resolves incompatible engine issues with npm being scoped to latest i.e:

```
 => ERROR [base 4/5] RUN npm install -g npm@latest                                                                                                                                                                                                               2.2s
------                                                                                                                                                                                                                                                                
 > [base 4/5] RUN npm install -g npm@latest:
2.042 npm ERR! code EBADENGINE
2.043 npm ERR! engine Unsupported engine
```